### PR TITLE
Refactor the paper_index increment approach

### DIFF
--- a/quenten/web/models.py
+++ b/quenten/web/models.py
@@ -327,19 +327,19 @@ class Person(BaseModel):
     def save(self, *args, **kwargs) -> None:
         """
         Override to set the paper_index from created_at and increment it.
+        Gets the list of all forms created in the same quarter as this one
+        and increments the count by 1.
         """
         super().save(*args, **kwargs)
 
         if not self.paper_index:
             quarter = (self.created_at.month + 2) // 3
-            increment = (
-                Person._base_manager.filter(
-                    created_at__year=self.created_at.year,
-                    created_at__quarter=quarter,
-                    created_at__lt=self.created_at,
-                ).count()
-                + 1
-            )
+            increment = Person.objects.filter(
+                created_at__year=self.created_at.year,
+                created_at__quarter=quarter,
+                created_at__lt=self.created_at,
+                ).count() + 1
+
             self.paper_index = int(f"{self.created_at.year}{quarter}{increment}")
 
         return super().save(*args, **kwargs)


### PR DESCRIPTION
Changes the approach to stop using the base manager, and just use the model directly.

This has been tested on MySql, so _should_ fix the problem for new data input.